### PR TITLE
:bug: Remove creation of extract destination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,5 +46,5 @@ jobs:
       - name: Upload Dist
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ steps.extract.outputs.destination }}/app
+          path: ${{ steps.extract.outputs.destination }}
           name: dist

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
       - name: Upload Dist
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ steps.extract.outputs.destination }}/app
+          path: ${{ steps.extract.outputs.destination }}
           name: dist
 ```
 
@@ -78,7 +78,7 @@ jobs:
       - name: Upload Dist
         uses: actions/upload-artifact@v2
         with:
-          path: ${{ steps.extract.outputs.destination }}/app
+          path: ${{ steps.extract.outputs.destination }}
           name: dist
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shrink/actions-docker-extract",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shrink/actions-docker-extract",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Extract from a Docker Image",
   "author": "Samuel Ryan <sam@samryan.co.uk>",
   "homepage": "https://github.com/shrink/actions-docker-extract#readme",

--- a/src/extract.js
+++ b/src/extract.js
@@ -8,7 +8,6 @@ async function run() {
     const destination = `.extracted-${Date.now()}`;
     const create = `docker cp $(docker create ${image}):/${path} ${destination}`;
 
-    await exec.exec(`mkdir -p ${destination}`);
     await exec.exec(`/bin/bash -c "${create}"`, []);
 
     core.setOutput('destination', destination);


### PR DESCRIPTION
https://docs.docker.com/engine/reference/commandline/cp/

Current behaviour:

> DEST_PATH exists and is a directory [...] the source directory is copied into this directory

Desired behaviour:

> DEST_PATH does not exist [...] DEST_PATH is created as a directory and the contents of the source directory are copied into this directory