### PR TITLE
chore: Update Actions node version to `16`

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Docker Machine
         run: |
-          brew install docker docker-machine
+          brew install docker docker-machine virtualbox
           docker-machine create --driver virtualbox default
           eval $(docker-machine env default)
           env | grep DOCKER >> $GITHUB_ENV

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -20,7 +20,7 @@ jobs:
     name: Extract Example File on macOS
     steps:
       - uses: actions/checkout@v2
-      - name: Install Docker Machine
+      - name: Install Docker
         env:
           HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
         run: |

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -20,12 +20,7 @@ jobs:
     name: Extract Example File on macOS
     steps:
       - uses: actions/checkout@v2
-      - name: Install Docker Machine
-        run: |
-          brew install docker docker-machine virtualbox
-          docker-machine create --driver virtualbox default
-          eval $(docker-machine env default)
-          env | grep DOCKER >> $GITHUB_ENV
+      - uses: docker-practice/actions-setup-docker@master
       - run: docker build -t example:${{ github.sha }} ./.github/tests
       - uses: ./
         id: extract

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -24,10 +24,8 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
         run: |
-          brew install docker docker-machine virtualbox
-          docker-machine create --driver virtualbox default
-          eval $(docker-machine env default)
-          env | grep DOCKER >> $GITHUB_ENV
+          brew install docker colima
+          colima start
       - run: docker build -t example:${{ github.sha }} ./.github/tests
       - uses: ./
         id: extract

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -20,7 +20,14 @@ jobs:
     name: Extract Example File on macOS
     steps:
       - uses: actions/checkout@v2
-      - uses: docker-practice/actions-setup-docker@master
+      - name: Install Docker Machine
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
+        run: |
+          brew install docker docker-machine virtualbox
+          docker-machine create --driver virtualbox default
+          eval $(docker-machine env default)
+          env | grep DOCKER >> $GITHUB_ENV
       - run: docker build -t example:${{ github.sha }} ./.github/tests
       - uses: ./
         id: extract

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ outputs:
   destination:
     description: 'Destination of extracted file(s)'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'scissors'

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@shrink/actions-docker-extract",
-  "version": "1.0.2",
   "description": "Extract from a Docker Image",
   "author": "Samuel Ryan <sam@samryan.co.uk>",
+  "private": true,
   "homepage": "https://github.com/shrink/actions-docker-extract#readme",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Per #11, version 12 of node is soon to be deprecated.