### PR TITLE
ci: Do not skip build action job on `release` branch

### DIFF
--- a/.github/workflows/build_action.yaml
+++ b/.github/workflows/build_action.yaml
@@ -5,13 +5,14 @@ on: [workflow_call]
 jobs:
   build-action:
     runs-on: ubuntu-latest
-    if: "!startsWith(github.ref, 'refs/heads/release')"
     steps:
       - uses: actions/checkout@v2
       - run: npm install
       - name: Build action (if not already built)
+        if: "!startsWith(github.ref, 'refs/heads/release')"
         run: npm run build
       - name: Push build into cache
+        if: "!startsWith(github.ref, 'refs/heads/release')"
         uses: actions/cache@v3
         with:
           path: dist


### PR DESCRIPTION
The dependent jobs will not run if the job is skipped: skip the steps instead.