### PR TITLE
feat: Run action on `node20`

### DIFF
--- a/.github/workflows/directory.yml
+++ b/.github/workflows/directory.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Load action build from cache
         uses: actions/cache@v3
         with:
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Load action build from cache
         uses: actions/cache@v3
         with:
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Load action build from cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Load action build from cache
         uses: actions/cache@v3
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Load action build from cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/package-action.yaml
+++ b/.github/workflows/package-action.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: pr-mpt/actions-merge-branch@v2
+      - uses: prompt/actions-merge-branch@v2
         with:
           from: "origin/${{ env.source }}"
           commit: false

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Load action build from cache
         uses: actions/cache@v3
         with:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: Install Docker
         uses: douglascamata/setup-docker-macos-action@main
       - run: docker build -t example:${{ github.sha }} ./.github/tests

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Install Docker
         uses: douglascamata/setup-docker-macos-action@main
       - run: docker build -t example:${{ github.sha }} ./.github/tests
-      - run: npm install
-      - run: npm run build
+      - name: Load action build from cache
+        uses: actions/cache@v3
+        with:
+          path: dist
+          key: build-${{ github.sha }}
       - uses: ./
         id: extract
         with:

--- a/.github/workflows/validate-tag.yaml
+++ b/.github/workflows/validate-tag.yaml
@@ -13,10 +13,10 @@ jobs:
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
       - name: Test that the tagged commit includes `dist`
-        uses: pr-mpt/actions-assert@v2
+        uses: prompt/actions-assert@v2
         with:
           assertion: npm://@assertions/directory-exists
           expected: dist
       - if: failure()
         name: Delete invalid tag
-        uses: pr-mpt/actions-delete-tag@v1
+        uses: prompt/actions-delete-tag@v1

--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build Docker Image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v5
         with:
           repository: my-example-image
           tags: latest
-      - uses: shrink/actions-docker-extract@v2
+      - uses: shrink/actions-docker-extract@v3
         id: extract
         with:
           image: my-example-image
           path: /app/.
       - name: Upload Dist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ steps.extract.outputs.destination }}
           name: dist
@@ -94,8 +94,8 @@ tag. Any reference to this Action in a Workflow must use a [tag][tags] (mutable)
 or the commit hash of a tag (immutable).
 
 ```yaml
-✅ uses: shrink/actions-docker-extract@v2
-✅ uses: shrink/actions-docker-extract@v2.0.0
+✅ uses: shrink/actions-docker-extract@v3
+✅ uses: shrink/actions-docker-extract@v3.0.0
 ✅ uses: shrink/actions-docker-extract@40400b42f4f8b663c647f535e2c6674658e39fc6
 ❌ uses: shrink/actions-docker-extract@main
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A GitHub Action for extracting files from a Docker Image.
 
 ```yaml
-- uses: shrink/actions-docker-extract@v2
+- uses: shrink/actions-docker-extract@v3
   with:
     image: "ghost:alpine"
     path: "/var/lib/ghost/current/core/built/assets/."
@@ -68,20 +68,20 @@ jobs:
   extract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
-      - uses: shrink/actions-docker-extract@v2
+      - uses: shrink/actions-docker-extract@v3
         id: extract
         with:
           image: ghcr.io/${{ github.repository }}:latest
           path: /app/.
       - name: Upload Dist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ steps.extract.outputs.destination }}
           name: dist

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ outputs:
   destination:
     description: 'Destination of extracted file(s)'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'scissors'

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "lint": "eslint 'src/**.js' --fix",
     "commit": "npm run-script lint && npm run-script build"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/shrink/actions-document-sign.git"
-  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/shrink/actions-docker-extract/issues"


### PR DESCRIPTION
The build happens on v16 still because ncc doesn't support v20 yet but that's okay as it's not doing anything required for v20.