### PR TITLE
fix: Remove period (`.`) from destination path

### DIFF
--- a/.github/workflows/build_action.yaml
+++ b/.github/workflows/build_action.yaml
@@ -6,8 +6,8 @@ jobs:
   build-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - run: npm install
@@ -16,7 +16,7 @@ jobs:
         run: npm run build
       - name: Push build into cache
         if: "!startsWith(github.ref, 'refs/heads/release')"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}

--- a/.github/workflows/directory.yml
+++ b/.github/workflows/directory.yml
@@ -11,12 +11,12 @@ jobs:
       - action
     name: Extract Contents of Directory from Example Image
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Load action build from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}
@@ -38,12 +38,12 @@ jobs:
       - action
     name: Extract Nested Directory from Example Image
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Load action build from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}
@@ -61,12 +61,12 @@ jobs:
       - action
     name: Extract Nested Contents of Directory from Example Image
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Load action build from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}

--- a/.github/workflows/file.yml
+++ b/.github/workflows/file.yml
@@ -11,12 +11,12 @@ jobs:
       - action
     name: Extract Example File From Root of Built Image
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Load action build from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}
@@ -33,12 +33,12 @@ jobs:
       - action
     name: Extract Nexted Example File From Built Image
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Load action build from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}

--- a/.github/workflows/package-action.yaml
+++ b/.github/workflows/package-action.yaml
@@ -13,12 +13,12 @@ jobs:
   package-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: "${{ env.release }}"
           fetch-depth: 0
           ssh-key: "${{ secrets.COMMIT_KEY }}"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - uses: prompt/actions-merge-branch@v2

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -29,6 +29,7 @@ jobs:
       - run: test -e ${{ steps.extract.outputs.destination }}/001.txt || exit 1
   macos:
     runs-on: macos-13
+    if: false # Temporarily disabled due to issues with Docker in macos GitHub Runners
     needs:
       - action
     name: Extract Example File on macOS

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -11,12 +11,12 @@ jobs:
       - action
     name: Extract Example File on Ubuntu
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Load action build from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}
@@ -33,15 +33,15 @@ jobs:
       - action
     name: Extract Example File on macOS
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install Docker
         uses: douglascamata/setup-docker-macos-action@main
       - run: docker build -t example:${{ github.sha }} ./.github/tests
       - name: Load action build from cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: build-${{ github.sha }}

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -28,7 +28,7 @@ jobs:
           path: /files/001.txt
       - run: test -e ${{ steps.extract.outputs.destination }}/001.txt || exit 1
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     needs:
       - action
     name: Extract Example File on macOS

--- a/.github/workflows/validate-tag.yaml
+++ b/.github/workflows/validate-tag.yaml
@@ -9,7 +9,7 @@ jobs:
   validate-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
       - name: Test that the tagged commit includes `dist`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ A GitHub Action for extracting files from a Docker Image.
     path: "/var/lib/ghost/current/core/built/assets/."
 ```
 
+:warning: Due to a breaking change in v3 of GitHub's actions/upload-artifact, a
+low-impact breaking change has been made to v3.0.1 of this action. Please
+see [issues#28](https://github.com/shrink/actions-docker-extract/issues/28) for
+context and support.
+
 ## Inputs
 
 | ID            | Description                                          | Required | Examples                                      |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A GitHub Action for extracting files from a Docker Image.
 
 | ID            | Description                                       | Example                  |
 | ------------- | ------------------------------------------------- | ------------------------ |
-| `destination` | Destination path containing the extracted file(s) | `.extracted-1598717412/` |
+| `destination` | Destination path containing the extracted file(s) | `extracted-1598717412/` |
 
 ## Examples
 

--- a/src/extract.js
+++ b/src/extract.js
@@ -7,6 +7,14 @@ async function run() {
     const path = core.getInput('path');
     const destination = core.getInput('destination') || `extracted-${Date.now()}`;
 
+    if (!core.getInput('destination')) {
+      core.notice([
+        'As you did not specify a destination, the default is being used.',
+        'As of version shrink/actions-docker-extract@3.0.1, the default does not include a dot prefix.',
+        'See https://github.com/shrink/actions-docker-extract/issues/28 for context.',
+      ].join(' '));
+    }
+
     const create = `docker cp $(docker create ${image}):/${path} ${destination}`;
 
     await exec.exec(`mkdir -p ${destination}`);

--- a/src/extract.js
+++ b/src/extract.js
@@ -11,7 +11,7 @@ async function run() {
       core.notice([
         'As you did not specify a docker extract destination, the default is being used.',
         'As of shrink/actions-docker-extract@3.0.1 the default does not include a dot prefix.',
-        `v3.0.0: "${destination}", v3.0.1: ".${destination}"`,
+        `v3.0.0: ".${destination}", v3.0.1: "${destination}"`,
         'See https://github.com/shrink/actions-docker-extract/issues/28 for context.',
         'No action is required unless this Workflow depends upon the dot prefix.',
       ].join(' '));

--- a/src/extract.js
+++ b/src/extract.js
@@ -9,9 +9,11 @@ async function run() {
 
     if (!core.getInput('destination')) {
       core.notice([
-        'As you did not specify a destination, the default is being used.',
-        'As of version shrink/actions-docker-extract@3.0.1, the default does not include a dot prefix.',
+        'As you did not specify a docker extract destination, the default is being used.',
+        'As of shrink/actions-docker-extract@3.0.1 the default does not include a dot prefix.',
+        `v3.0.0: "${destination}", v3.0.1: ".${destination}"`,
         'See https://github.com/shrink/actions-docker-extract/issues/28 for context.',
+        'No action is required unless this Workflow depends upon the dot prefix.'
       ].join(' '));
     }
 

--- a/src/extract.js
+++ b/src/extract.js
@@ -13,7 +13,7 @@ async function run() {
         'As of shrink/actions-docker-extract@3.0.1 the default does not include a dot prefix.',
         `v3.0.0: "${destination}", v3.0.1: ".${destination}"`,
         'See https://github.com/shrink/actions-docker-extract/issues/28 for context.',
-        'No action is required unless this Workflow depends upon the dot prefix.'
+        'No action is required unless this Workflow depends upon the dot prefix.',
       ].join(' '));
     }
 

--- a/src/extract.js
+++ b/src/extract.js
@@ -10,7 +10,7 @@ async function run() {
     if (!core.getInput('destination')) {
       core.notice([
         'As you did not specify a docker extract destination, the default is being used.',
-        'As of shrink/actions-docker-extract@3.0.1 the default does not include a dot prefix.',
+        'As of shrink/actions-docker-extract@v3.0.1 the default does not include a dot prefix.',
         `v3.0.0: ".${destination}", v3.0.1: "${destination}"`,
         'See https://github.com/shrink/actions-docker-extract/issues/28 for context.',
         'No action is required unless this Workflow depends upon the dot prefix.',

--- a/src/extract.js
+++ b/src/extract.js
@@ -5,7 +5,7 @@ async function run() {
   try {
     const image = core.getInput('image');
     const path = core.getInput('path');
-    const destination = core.getInput('destination') || `.extracted-${Date.now()}`;
+    const destination = core.getInput('destination') || `extracted-${Date.now()}`;
 
     const create = `docker cp $(docker create ${image}):/${path} ${destination}`;
 


### PR DESCRIPTION
GitHub's `actions/upload-artifact` ignores dotfiles by default now (a breaking change) so this Action will not work as expected for users impacted by that change. The change here is technically breaking (as the default destination will no longer start with a `.`) but because the destination name is randomly generated, it should not impact any integrations.

context: https://github.com/shrink/actions-docker-extract/issues/28