### PR TITLE
Allow for choice of shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ context and support.
 | `image`       | Docker Image to extract files from                   |    ✅    | `alpine` `ghcr.io/github/super-linter:latest` |
 | `path`        | Path (from root) to a file or directory within Image |    ✅    | `files/example.txt` `files` `files/.`         |
 | `destination` | Destination path for the extracted files             |    ❌    | `/foo/` `~/` `./foo/bar`                      |
+| `shell`       | The shell to use for extraction                      |    ❌    | `/bin/bash` `/bin/sh`                         |
 
 > :paperclip: To copy the **contents** of a directory the `path` must end with
 > `/.` otherwise the directory itself will be copied. More information about the

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   destination:
     description: 'Destination path for the extracted files'
     required: false
+  shell:
+    description: 'The shell to use for extraction (default: /bin/bash)'
+    required: false
+    default: '/bin/bash'
 outputs:
   destination:
     description: 'Destination of extracted file(s)'

--- a/src/extract.js
+++ b/src/extract.js
@@ -6,9 +6,7 @@ async function run() {
     const image = core.getInput('image');
     const path = core.getInput('path');
     const destination = core.getInput('destination') || `extracted-${Date.now()}`;
-    const shell = core.getInput('shell', {
-      default: '/bin/bash',
-    });
+    const shell = core.getInput('shell');
 
     if (!core.getInput('destination')) {
       core.notice([

--- a/src/extract.js
+++ b/src/extract.js
@@ -6,6 +6,9 @@ async function run() {
     const image = core.getInput('image');
     const path = core.getInput('path');
     const destination = core.getInput('destination') || `extracted-${Date.now()}`;
+    const shell = core.getInput('shell', {
+      default: '/bin/bash',
+    });
 
     if (!core.getInput('destination')) {
       core.notice([
@@ -20,12 +23,12 @@ async function run() {
     const create = `docker cp $(docker create ${image}):/${path} ${destination}`;
 
     await exec.exec(`mkdir -p ${destination}`);
-    await exec.exec(`/bin/bash -c "${create}"`, []);
+    await exec.exec(`${shell} -c "${create}"`, []);
 
     core.setOutput('destination', destination);
   } catch (error) {
     core.setFailed(error.message);
   }
-}
+};
 
 run();


### PR DESCRIPTION
# Description
This change gives users the option to set the shell under which the `docker cp` command will run. It uses `/bin/bash` by default, so the change should be backwards compatible.

Solves #30 